### PR TITLE
reintroduced itemid

### DIFF
--- a/docs/openapi/schemas-pn-address.yaml
+++ b/docs/openapi/schemas-pn-address.yaml
@@ -20,7 +20,11 @@ components:
       type: object
       required:
         - address
+        - id
       properties:
+        id:
+          type: string
+          description: identificativo oggetto
         address:
           $ref: '#/components/schemas/AnalogAddress'
 
@@ -41,7 +45,12 @@ components:
             
     NormalizeResult:
       type: object
+      required:
+        - id
       properties:
+        id:
+          type: string
+          description: identificativo oggetto
         normalizedAddress:
           $ref: '#/components/schemas/AnalogAddress'
         error:


### PR DESCRIPTION
Necessario per disambiguare le diverse richieste contenute all'interno della lista.
L'alternativa è quella di basarsi sull'ordine