### PR TITLE
Hotfix/nameRow2

### DIFF
--- a/docs/openapi/schemas-pn-address.yaml
+++ b/docs/openapi/schemas-pn-address.yaml
@@ -128,4 +128,8 @@ components:
           type: string
           description: "In caso di destinatario estero, diventa obbligatoria l’indicazione\
             \ della nazione di destinazione,  in standard UPU o altro standard condiviso."
+        nameRow2:
+          x-field-extra-annotation: "@lombok.ToString.Exclude" # NO EXTERNAL
+          type: string
+          description: Seconda riga sulla busta.
       

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>pn-address-manager</artifactId>
-	<version>2.0.3</version>
+	<version>2.0.4-SNAPSHOT</version>
 	<name>pn-address-manager</name>
 	<description>PN Address Manager</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>pn-address-manager</artifactId>
-	<version>2.0.3-RC.1</version>
+	<version>2.0.3</version>
 	<name>pn-address-manager</name>
 	<description>PN Address Manager</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>pn-address-manager</artifactId>
-	<version>2.0.3-SNAPSHOT</version>
+	<version>2.0.3-RC.1</version>
 	<name>pn-address-manager</name>
 	<description>PN Address Manager</description>
 

--- a/src/main/java/it/pagopa/pn/address/manager/utils/AddressUtils.java
+++ b/src/main/java/it/pagopa/pn/address/manager/utils/AddressUtils.java
@@ -86,6 +86,7 @@ public class AddressUtils {
         analogAddress.setAddressRow2(Optional.ofNullable(analogAddress.getAddressRow2()).map(s -> StringUtils.normalizeSpace(s).toUpperCase()).orElse(null));
         analogAddress.setCity2(Optional.ofNullable(analogAddress.getCity2()).map(s -> StringUtils.normalizeSpace(s).toUpperCase()).orElse(null));
         analogAddress.setCountry(Optional.ofNullable(analogAddress.getCountry()).map(s -> StringUtils.normalizeSpace(s).toUpperCase()).orElse(null));
+        analogAddress.setNameRow2(Optional.ofNullable(analogAddress.getNameRow2()).map(s -> StringUtils.normalizeSpace(s).toUpperCase()).orElse(null));
         return analogAddress;
     }
 


### PR DESCRIPTION
@flaminiaScarciofolo @federicofatica oltre ad aggiungere il campo nameRow2 in AnalogAddress, ho aggiunto la gestione d quest'ultimo anche nel metodo `toUpperCase` richiamato dal metodo `normalizeAddress` (ma non so se è giusto).